### PR TITLE
Add material as default icon type and update icon example

### DIFF
--- a/examples/mirai_gallery/assets/json/icon_example.json
+++ b/examples/mirai_gallery/assets/json/icon_example.json
@@ -53,7 +53,7 @@
                 "type": "container",
                 "child": {
                   "type": "icon",
-                  "iconType": "material",
+                  "iconType": "cupertino",
                   "icon": "add",
                   "size": 32
                 }
@@ -66,8 +66,8 @@
                 "type": "container",
                 "child": {
                   "type": "icon",
-                  "iconType": "material",
-                  "icon": "remove",
+                  "iconType": "cupertino",
+                  "icon": "minus",
                   "size": 32
                 }
               }

--- a/packages/mirai/lib/src/parsers/mirai_icon/mirai_icon.dart
+++ b/packages/mirai/lib/src/parsers/mirai_icon/mirai_icon.dart
@@ -13,7 +13,7 @@ part 'mirai_icon.g.dart';
 class MiraiIcon with _$MiraiIcon {
   const factory MiraiIcon({
     required String icon,
-    required IconType iconType,
+    @Default(IconType.material) IconType iconType,
     double? size,
     String? color,
     String? semanticLabel,

--- a/packages/mirai/lib/src/parsers/mirai_icon/mirai_icon.freezed.dart
+++ b/packages/mirai/lib/src/parsers/mirai_icon/mirai_icon.freezed.dart
@@ -173,7 +173,7 @@ class __$$MiraiIconImplCopyWithImpl<$Res>
 class _$MiraiIconImpl implements _MiraiIcon {
   const _$MiraiIconImpl(
       {required this.icon,
-      required this.iconType,
+      this.iconType = IconType.material,
       this.size,
       this.color,
       this.semanticLabel,
@@ -185,6 +185,7 @@ class _$MiraiIconImpl implements _MiraiIcon {
   @override
   final String icon;
   @override
+  @JsonKey()
   final IconType iconType;
   @override
   final double? size;
@@ -240,7 +241,7 @@ class _$MiraiIconImpl implements _MiraiIcon {
 abstract class _MiraiIcon implements MiraiIcon {
   const factory _MiraiIcon(
       {required final String icon,
-      required final IconType iconType,
+      final IconType iconType,
       final double? size,
       final String? color,
       final String? semanticLabel,

--- a/packages/mirai/lib/src/parsers/mirai_icon/mirai_icon.g.dart
+++ b/packages/mirai/lib/src/parsers/mirai_icon/mirai_icon.g.dart
@@ -9,7 +9,8 @@ part of 'mirai_icon.dart';
 _$MiraiIconImpl _$$MiraiIconImplFromJson(Map<String, dynamic> json) =>
     _$MiraiIconImpl(
       icon: json['icon'] as String,
-      iconType: $enumDecode(_$IconTypeEnumMap, json['iconType']),
+      iconType: $enumDecodeNullable(_$IconTypeEnumMap, json['iconType']) ??
+          IconType.material,
       size: (json['size'] as num?)?.toDouble(),
       color: json['color'] as String?,
       semanticLabel: json['semanticLabel'] as String?,


### PR DESCRIPTION
## Description

In this PR, I updated the default value of the `iconType` in the Mirai Icon widget to `material` and modified the icon example to include Cupertino icons.

## Related Issues

<!--- List the related issues to this PR -->
Closes #98

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
