### PR TITLE
Fix: change all icon button widget property from child to icon in app…

### DIFF
--- a/examples/mirai_gallery/assets/json/app_bar_example.json
+++ b/examples/mirai_gallery/assets/json/app_bar_example.json
@@ -8,7 +8,7 @@
     },
     "leading": {
       "type": "iconButton",
-      "child": {
+      "icon": {
         "type": "icon",
         "iconType": "material",
         "icon": "menu"
@@ -19,7 +19,7 @@
     "actions": [
       {
         "type": "iconButton",
-        "child": {
+        "icon": {
           "type": "icon",
           "iconType": "cupertino",
           "icon": "heart_solid"
@@ -28,7 +28,7 @@
       },
       {
         "type": "iconButton",
-        "child": {
+        "icon": {
           "type": "icon",
           "iconType": "material",
           "icon": "search"
@@ -37,7 +37,7 @@
       },
       {
         "type": "iconButton",
-        "child": {
+        "icon": {
           "type": "icon",
           "iconType": "material",
           "icon": "more_horiz"

--- a/examples/mirai_gallery/assets/json/icon_button_example.json
+++ b/examples/mirai_gallery/assets/json/icon_button_example.json
@@ -24,7 +24,7 @@
             "children": [
               {
                 "type": "iconButton",
-                "child": {
+                "icon": {
                   "type": "icon",
                   "iconType": "material",
                   "icon": "add"
@@ -37,7 +37,7 @@
               },
               {
                 "type": "iconButton",
-                "child": {
+                "icon": {
                   "type": "icon",
                   "iconType": "material",
                   "icon": "remove"
@@ -57,7 +57,7 @@
             "children": [
               {
                 "type": "iconButton",
-                "child": {
+                "icon": {
                   "type": "icon",
                   "iconType": "material",
                   "icon": "add"
@@ -69,7 +69,7 @@
               },
               {
                 "type": "iconButton",
-                "child": {
+                "icon": {
                   "type": "icon",
                   "iconType": "material",
                   "icon": "remove"

--- a/examples/mirai_gallery/assets/json/scaffold_example.json
+++ b/examples/mirai_gallery/assets/json/scaffold_example.json
@@ -8,7 +8,7 @@
     },
     "leading": {
       "type": "iconButton",
-      "child": {
+      "icon": {
         "type": "icon",
         "iconType": "material",
         "icon": "menu"
@@ -18,7 +18,7 @@
     "actions": [
       {
         "type": "iconButton",
-        "child": {
+        "icon": {
           "type": "icon",
           "iconType": "cupertino",
           "icon": "heart_solid"
@@ -27,7 +27,7 @@
       },
       {
         "type": "iconButton",
-        "child": {
+        "icon": {
           "type": "icon",
           "iconType": "material",
           "icon": "search"
@@ -36,7 +36,7 @@
       },
       {
         "type": "iconButton",
-        "child": {
+        "icon": {
           "type": "icon",
           "iconType": "material",
           "icon": "more_horiz"


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

In this PR, Currently, the app bar, the icon button, and the scaffold example screens do not display the icon. So I've updated all the example screen that uses the icon button from `child` to `icon` property

## Related Issues

<!--- List the related issues to this PR -->
Closes #182

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
